### PR TITLE
Make custom EndpointManager usable

### DIFF
--- a/logmatic/src/main/java/io/logmatic/android/LogmaticAppender.java
+++ b/logmatic/src/main/java/io/logmatic/android/LogmaticAppender.java
@@ -55,8 +55,12 @@ public class LogmaticAppender {
         Log.i(getClass().getSimpleName(), "Network state initialization, isConnected: " + isConnected);
 
         if (manager == null) {
-            Endpoint endpoint = new SecureTCPEndpoint(SecureTCPEndpoint.LOGMATIC_DST_HOST, SecureTCPEndpoint.LOGMATIC_SSL_DST_PORT);
+            Endpoint endpoint = new SecureTCPEndpoint(
+                SecureTCPEndpoint.LOGMATIC_DST_HOST, SecureTCPEndpoint.LOGMATIC_SSL_DST_PORT
+            );
             this.manager = new EndpointManager(endpoint);
+        } else {
+            this.manager = manager;
         }
 
         this.token = token;


### PR DESCRIPTION
This would make it possible to create a custom Endpoint and use it in the appender instead of the default one. Could come in handy for easy migration