### PR TITLE
Move to AndroidX artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -14,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.useAndroidX=true
+android.enableJetifier=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 25 16:17:56 CET 2016
+#Wed May 18 16:11:02 CEST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/logmatic/build.gradle
+++ b/logmatic/build.gradle
@@ -8,7 +8,6 @@ ext {
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
 
     defaultConfig {
         minSdkVersion 16

--- a/logmatic/build.gradle
+++ b/logmatic/build.gradle
@@ -28,19 +28,19 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.google.code.gson:gson:2.7'
-    compile 'androidx.legacy:legacy-support-v13:1.0.0'
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'com.google.code.gson:gson:2.7'
+    implementation 'androidx.legacy:legacy-support-v13:1.0.0'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'org.hamcrest:hamcrest-library:1.3'
 
-    androidTestCompile 'androidx.test:runner:0.5'
-    androidTestCompile 'androidx.test:rules:0.5'
-    androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'org.mockito:mockito-core:1.10.19'
-    androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
+    androidTestImplementation 'androidx.test:runner:0.5'
+    androidTestImplementation 'androidx.test:rules:0.5'
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'org.mockito:mockito-core:1.10.19'
+    androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
 }
 
 

--- a/logmatic/build.gradle
+++ b/logmatic/build.gradle
@@ -30,14 +30,14 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.google.code.gson:gson:2.7'
-    compile 'com.android.support:support-v13:25.0.1'
+    compile 'androidx.legacy:legacy-support-v13:1.0.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
 
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
+    androidTestCompile 'androidx.test:runner:0.5'
+    androidTestCompile 'androidx.test:rules:0.5'
     androidTestCompile 'junit:junit:4.12'
     androidTestCompile 'org.mockito:mockito-core:1.10.19'
     androidTestCompile 'org.hamcrest:hamcrest-library:1.3'

--- a/logmatic/src/main/java/io/logmatic/android/Logger.java
+++ b/logmatic/src/main/java/io/logmatic/android/Logger.java
@@ -1,9 +1,9 @@
 package io.logmatic.android;
 
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v4.util.ArrayMap;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.collection.ArrayMap;
 import android.util.Log;
 
 import com.google.gson.FieldNamingPolicy;

--- a/logmatic/src/main/java/io/logmatic/android/LoggerBuilder.java
+++ b/logmatic/src/main/java/io/logmatic/android/LoggerBuilder.java
@@ -1,8 +1,8 @@
 package io.logmatic.android;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v4.util.ArrayMap;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.collection.ArrayMap;
 
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;

--- a/logmatic/src/main/java/io/logmatic/android/LoggerRegistry.java
+++ b/logmatic/src/main/java/io/logmatic/android/LoggerRegistry.java
@@ -1,7 +1,7 @@
 package io.logmatic.android;
 
-import android.support.annotation.NonNull;
-import android.support.v4.util.ArrayMap;
+import androidx.annotation.NonNull;
+import androidx.collection.ArrayMap;
 import android.util.Log;
 
 import java.util.Map;


### PR DESCRIPTION
I use logmatic in my project and would like to disable Jetifier. Logmatic is the last dependency with legacy Android support libraries usage.

This PR aims to replace with AndroidX artifacts.